### PR TITLE
Update supervisord.conf

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -3,6 +3,18 @@ nodaemon=true
 pidfile=/root/supervisord.pid
 logfile=/root/supervisord.log
 
+[program:beforevnc1]
+command=/usr/bin/rm -rf /tmp/.X11-unix
+autostart=true
+autorestart=false
+redirect_stderr=true
+
+[program:beforevnc2]
+command=/usr/bin/rm -rf /tmp/.X1-lock
+autostart=true
+autorestart=false
+redirect_stderr=true
+
 [program:vncserver]
 command=vncserver
 stdout_logfile=/root/x11vnc.log


### PR DESCRIPTION
Adding two segments in supervisord.conf to remove x11 temporary lock files under /tmp, those files affect VNC Client to connect properly after restarting the container.